### PR TITLE
Improved: bottom padding in the selectFacilityModal for favIcon (#19)

### DIFF
--- a/src/components/SelectFacilityModal.vue
+++ b/src/components/SelectFacilityModal.vue
@@ -9,7 +9,6 @@
       <ion-title>{{ translate("Select facilities") }}</ion-title>
     </ion-toolbar>
   </ion-header>
-  
   <ion-content>
     <ion-list>
       <ion-item v-for="facility in facilities" :key="facility.facilityId">
@@ -124,4 +123,9 @@ export default defineComponent({
   },
 });
 </script>
-  
+
+<style scoped>
+ion-content {
+  --padding-bottom: 80px;
+}
+</style>

--- a/src/components/SelectFacilityModal.vue
+++ b/src/components/SelectFacilityModal.vue
@@ -9,6 +9,7 @@
       <ion-title>{{ translate("Select facilities") }}</ion-title>
     </ion-toolbar>
   </ion-header>
+
   <ion-content>
     <ion-list>
       <ion-item v-for="facility in facilities" :key="facility.facilityId">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #19

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added space at the bottom of the selectFacilityModal so as to give space for the favIcon to avoid overlapping of content.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2023-11-03 18-18-01](https://github.com/hotwax/user-management/assets/69574321/a1252521-87e0-4f43-bb96-111da454b017)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)