### PR TITLE
Fixed: Displayed groupName in the message for the facility user on Add Credential secion of user detail page..

### DIFF
--- a/src/views/FindUsers.vue
+++ b/src/views/FindUsers.vue
@@ -18,17 +18,17 @@
               <ion-icon :icon="idCardOutline" slot="start" />
               <ion-label>{{ translate("Clearance") }}</ion-label>
               <ion-select interface="popover" v-model="query.securityGroup" @ionChange="updateQuery()">
-                <ion-select-option :value="securityGroup.groupId" :key="index" v-for="(securityGroup, index) in securityGroups">{{ securityGroup.groupName }}</ion-select-option>
                 <ion-select-option value="">{{ translate("All") }}</ion-select-option>
+                <ion-select-option :value="securityGroup.groupId" :key="index" v-for="(securityGroup, index) in securityGroups">{{ securityGroup.groupName }}</ion-select-option>
               </ion-select>
             </ion-item>
             <ion-item lines="none">
               <ion-icon :icon="toggleOutline" slot="start" />
               <ion-label>{{ translate("Status") }}</ion-label>
               <ion-select interface="popover" v-model="query.status" @ionChange="updateQuery()">
+                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
                 <ion-select-option value="Y">{{ translate("Active") }}</ion-select-option>
                 <ion-select-option value="N">{{ translate("Inactive") }}</ion-select-option>
-                <ion-select-option value="">{{ translate("All") }}</ion-select-option>
               </ion-select>
             </ion-item>
           </ion-list>

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -67,7 +67,7 @@
                   <ion-item>
                     <ion-label class="ion-text-wrap" position="fixed">{{ translate("Password") }}</ion-label>
                     <ion-input :placeholder="translate('Default password')" name="password" v-model="password" id="password" type="password" required />
-                    <ion-note slot="helper">{{ translate('will be asked to reset their password when they login', { name: selectedUser.firstName }) }}</ion-note>
+                    <ion-note slot="helper">{{ translate('will be asked to reset their password when they login', { name: selectedUser.firstName ? selectedUser.firstName : selectedUser.groupName }) }}</ion-note>
                   </ion-item>
                 </ion-list>
                 <ion-button @click="createNewUserLogin()" fill="outline" expand="block">


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
Fixed: Displayed groupName in the message for the facility user on Add Credential secion of user detail page.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)