### PR TITLE
Implemented: single facility selection for facility login(#67)

### DIFF
--- a/src/components/SelectFacilityModal.vue
+++ b/src/components/SelectFacilityModal.vue
@@ -24,7 +24,10 @@
     <ion-list v-else>
       <ion-radio-group :value="selectedFacilities[0].facilityId" @ionChange="updateSelectedFacility($event)">
         <ion-item v-for="facility in facilities" :key="facility.facilityId">
-          <ion-label>{{ facility.facilityId }}</ion-label>
+          <ion-label>
+            {{ facility.facilityName }}
+            <p>{{ facility.facilityId }}</p>
+          </ion-label>
           <ion-radio slot="end" :value="facility.facilityId"></ion-radio>
         </ion-item>
       </ion-radio-group>

--- a/src/components/SelectFacilityModal.vue
+++ b/src/components/SelectFacilityModal.vue
@@ -103,16 +103,6 @@ export default defineComponent({
       modalController.dismiss({ dismissed: true });
     },
     saveFacilities() {
-      if(this.isFacilityLogin) {
-        modalController.dismiss({
-          dismissed: true,
-          value: {
-            selectedFacilities: this.selectedFacilityValues
-          }
-        })
-        return;
-      }
-
       // taking out the difference of selected facilities and the originally
       // user associated facilities for adding and removing facilities
       const facilitiesToAdd = this.selectedFacilityValues.filter((selectedFacility: any) => !this.selectedFacilities.some((facility: any) => facility.facilityId === selectedFacility.facilityId))

--- a/src/components/SelectFacilityModal.vue
+++ b/src/components/SelectFacilityModal.vue
@@ -11,7 +11,7 @@
   </ion-header>
 
   <ion-content>
-    <ion-list>
+    <ion-list v-if="!isFacilityLogin">
       <ion-item v-for="facility in facilities" :key="facility.facilityId">
         <ion-label>
           {{ facility.facilityName }}
@@ -20,7 +20,16 @@
         <ion-checkbox slot="end" :checked="isSelected(facility.facilityId)" @ionChange="toggleFacilitySelection(facility)" />
       </ion-item>
     </ion-list>
-  
+
+    <ion-list v-else>
+      <ion-radio-group :value="selectedFacilities[0].facilityId" @ionChange="updateSelectedFacility($event)">
+        <ion-item v-for="facility in facilities" :key="facility.facilityId">
+          <ion-label>{{ facility.facilityId }}</ion-label>
+          <ion-radio slot="end" :value="facility.facilityId"></ion-radio>
+        </ion-item>
+      </ion-radio-group>
+    </ion-list>
+
     <ion-fab @click="saveFacilities()" vertical="bottom" horizontal="end" slot="fixed">
       <ion-fab-button>
         <ion-icon :icon="saveOutline" />  
@@ -42,6 +51,8 @@ import {
   IonItem,
   IonLabel,
   IonList,
+  IonRadio,
+  IonRadioGroup,
   IonTitle,
   IonToolbar,
   modalController
@@ -65,10 +76,12 @@ export default defineComponent({
     IonItem,
     IonLabel,
     IonList,
+    IonRadio,
+    IonRadioGroup,
     IonTitle,
     IonToolbar,
   },
-  props: ["selectedFacilities"],
+  props: ["selectedFacilities", "isFacilityLogin"],
   data() {
     return {
       selectedFacilityValues: JSON.parse(JSON.stringify(this.selectedFacilities)),
@@ -87,6 +100,16 @@ export default defineComponent({
       modalController.dismiss({ dismissed: true });
     },
     saveFacilities() {
+      if(this.isFacilityLogin) {
+        modalController.dismiss({
+          dismissed: true,
+          value: {
+            selectedFacilities: this.selectedFacilityValues
+          }
+        })
+        return;
+      }
+
       // taking out the difference of selected facilities and the originally
       // user associated facilities for adding and removing facilities
       const facilitiesToAdd = this.selectedFacilityValues.filter((selectedFacility: any) => !this.selectedFacilities.some((facility: any) => facility.facilityId === selectedFacility.facilityId))
@@ -110,6 +133,9 @@ export default defineComponent({
     },
     isSelected(facilityId: any) {
       return this.selectedFacilityValues.some((facility: any) => facility.facilityId === facilityId);
+    },
+    updateSelectedFacility(event: CustomEvent) {
+      this.selectedFacilityValues = this.facilities.filter((facility: any) => facility.facilityId === event.detail.value)
     }
   },
   setup() {

--- a/src/store/modules/util/actions.ts
+++ b/src/store/modules/util/actions.ts
@@ -104,7 +104,9 @@ const actions: ActionTree<UtilState, RootState> = {
       const payload = {
         "inputFields": {
           "parentTypeId": "VIRTUAL_FACILITY",
-          "parentTypeId_op": "notEqual"
+          "parentTypeId_op": "notEqual",
+          "facilityTypeId": "VIRTUAL_FACILITY",
+          "facilityTypeId_op": "notEqual"
         },
         "entityName": "FacilityAndType",
         "viewSize": 100 // keeping view size 100 as considering that we will have max 100 facilities

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -550,9 +550,17 @@ export default defineComponent({
       return productStoreActionsPopover.present();
     },
     async selectFacility() {
+      let componentProps = {
+        selectedFacilities: this.selectedUser.facilities
+      } as any
+
+      if(this.selectedUser.partyTypeId === 'PARTY_GROUP') {
+        componentProps['isFacilityLogin'] = true
+      }
+
       const selectFacilityModal = await modalController.create({
         component: SelectFacilityModal,
-        componentProps: { selectedFacilities: this.selectedUser.facilities }
+        componentProps
       });
 
       selectFacilityModal.onDidDismiss().then( async (result) => {

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -66,7 +66,7 @@
               {{ facility.facilityName }}
               <p>{{ facility.facilityId }}</p>
             </ion-label>
-            <ion-checkbox slot="end" :checked="true" @ionChange="toggleFacilitySelection(facility)" />
+            <ion-checkbox v-if="!isFacilityLogin" slot="end" :checked="true" @ionChange="toggleFacilitySelection(facility)" />
           </ion-item>
         </ion-list>
 
@@ -429,7 +429,7 @@ export default defineComponent({
     async addFacilities() {
       const selectFacilityModal = await modalController.create({
         component: SelectFacilityModal,
-        componentProps: { selectedFacilities: this.selectedFacilities }
+        componentProps: { selectedFacilities: this.selectedFacilities, isFacilityLogin: this.isFacilityLogin() }
       });
 
       selectFacilityModal.onDidDismiss().then((result) => {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #67

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Implemented logic such that user with facility login can only select one facility to be associated with at a time.
Added filter to exclude virtual facilities while fetching facilites for facility login user.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2023-12-26 10-37-01](https://github.com/hotwax/user-management/assets/69574321/2ec33487-6732-4210-869f-9a301a2830dc)


![Screenshot from 2023-12-22 15-15-47](https://github.com/hotwax/user-management/assets/69574321/f653ac0a-e6b9-42a7-ac12-6cc0efb8aa22)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)