### PR TITLE
Improved: visibility of current user on top of find users page (#60)

### DIFF
--- a/src/views/FindUsers.vue
+++ b/src/views/FindUsers.vue
@@ -47,12 +47,13 @@
         </aside>
 
         <main v-if="users?.length">
-          <div class="list-item" v-if="currentUser.partyId" @click=viewUserDetails(currentUser.partyId)>
+          <ion-card class="list-item" v-if="currentUser.partyId" @click=viewUserDetails(currentUser.partyId)>
             <ion-item lines="none">
               <ion-label>
                 {{ currentUser.groupName ? currentUser.groupName : `${currentUser.firstName} ${currentUser.lastName}` }}
                 <p>{{ currentUser.userLoginId }}</p>
                 <p>{{ currentUser.infoString }}</p>
+                <ion-badge>{{ translate("Your user") }}</ion-badge>
               </ion-label>
             </ion-item>
 
@@ -66,15 +67,17 @@
               </ion-label>
             </div>
 
-            <div class="tablet">
-              <ion-chip outline v-if="currentUser.securityGroupId">
-                <ion-label>{{ currentUser.securityGroupName }}</ion-label>
-              </ion-chip>
-              <ion-label v-else>
-                {{ '-' }}
-              </ion-label>
-            </div>
-          </div>
+            <ion-item lines="none">
+              <div class="tablet">
+                <ion-chip outline v-if="currentUser.securityGroupId">
+                  <ion-label>{{ currentUser.securityGroupName }}</ion-label>
+                </ion-chip>
+                <ion-label v-else>
+                  {{ '-' }}
+                </ion-label>
+              </div>
+            </ion-item>
+          </ion-card>
           <div class="list-item" v-for="(user, index) in users" :key="index" @click=viewUserDetails(user.partyId)>
             <ion-item lines="none">
               <ion-label>
@@ -131,6 +134,8 @@
 
 <script lang="ts">
 import {
+  IonBadge,
+  IonCard,
   IonChip,
   IonContent,
   IonFab,
@@ -175,6 +180,8 @@ export default defineComponent({
   name: 'FindUsers',
   components: {
     FilterMenu,
+    IonBadge,
+    IonCard,
     IonChip,
     IonContent,
     IonFab,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #60

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved visibility of current user on top of find users page.

- Added badge "Your user" for current user
- Displaying current user in card.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2023-12-26 18-10-08](https://github.com/hotwax/user-management/assets/69574321/1089e139-90a0-48bc-8c2e-506f228e8419)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)