### PR TITLE
Fixed: statusId for user showing opposite for disabled user in UI (#73)

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -44,7 +44,7 @@
                 <ion-item lines="none">
                   <ion-icon :icon="cloudyNightOutline" slot="start" />
                   <ion-label>{{ translate("Disable user") }}</ion-label>
-                  <ion-toggle :checked="selectedUser.statusId === 'PARTY_ENABLED'" @click="updateUserStatus($event)" slot="end" />
+                  <ion-toggle :checked="selectedUser.statusId === 'PARTY_DISABLED'" @click="updateUserStatus($event)" slot="end" />
                 </ion-item>
               </div>
             </ion-card>
@@ -830,7 +830,7 @@ export default defineComponent({
 
       const payload = {
         partyId: this.selectedUser.partyId,
-        statusId: isChecked ? 'PARTY_ENABLED' : 'PARTY_DISABLED'
+        statusId: isChecked ? 'PARTY_DISABLED' : 'PARTY_ENABLED'
       }
 
       emitter.emit('presentLoader')


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #73

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed issue when enabled user is showing disabled in UI.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)