### PR TITLE
Implemented: eye toggle in password to show and hide password (#88)

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -128,7 +128,7 @@
                 </ion-item>
                 <ion-item ref="password">
                   <ion-label class="ion-text-wrap" position="fixed">{{ translate("Password") }} <ion-text color="danger">*</ion-text></ion-label>
-                  <ion-input :placeholder="translate('Default password')" name="password" v-model="password" id="password" :type="showPassword ? 'text' : 'password'" @ionInput="validatePassword" required />
+                  <ion-input :placeholder="translate('Default password')" name="password" v-model="password" id="password" :type="showPassword ? 'text' : 'password'" @ionInput="validatePassword" @ionBlur="markPasswordTouched" required />
                   <ion-icon :icon="showPassword ? eyeOffOutline : eyeOutline" slot="end" @click="showPassword = !showPassword" />
                   <ion-note slot="helper">{{ translate('will be asked to reset their password when they login', { name: selectedUser.firstName ? selectedUser.firstName : selectedUser.groupName }) }}</ion-note>
                   <ion-note slot="error">{{ translate('Password should be at least 5 characters long and contain at least one number, alphabet and special character.') }}</ion-note>

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -129,7 +129,9 @@
                 <ion-item ref="password">
                   <ion-label class="ion-text-wrap" position="fixed">{{ translate("Password") }} <ion-text color="danger">*</ion-text></ion-label>
                   <ion-input :placeholder="translate('Default password')" name="password" v-model="password" id="password" :type="showPassword ? 'text' : 'password'" @ionInput="validatePassword" @ionBlur="markPasswordTouched" required />
-                  <ion-icon :icon="showPassword ? eyeOffOutline : eyeOutline" slot="end" @click="showPassword = !showPassword" />
+                  <ion-button @click="showPassword = !showPassword" slot="end" fill="clear">
+                    <ion-icon :icon="showPassword ? eyeOutline : eyeOffOutline" slot="icon-only" />
+                  </ion-button>
                   <ion-note slot="helper">{{ translate('will be asked to reset their password when they login', { name: selectedUser.firstName ? selectedUser.firstName : selectedUser.groupName }) }}</ion-note>
                   <ion-note slot="error">{{ translate('Password should be at least 5 characters long and contain at least one number, alphabet and special character.') }}</ion-note>
                 </ion-item>

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -128,7 +128,8 @@
                 </ion-item>
                 <ion-item ref="password">
                   <ion-label class="ion-text-wrap" position="fixed">{{ translate("Password") }} <ion-text color="danger">*</ion-text></ion-label>
-                  <ion-input :placeholder="translate('Default password')" name="password" v-model="password" id="password" type="password" @ionInput="validatePassword" @ionBlur="markPasswordTouched" required />
+                  <ion-input :placeholder="translate('Default password')" name="password" v-model="password" id="password" :type="showPassword ? 'text' : 'password'" @ionInput="validatePassword" required />
+                  <ion-icon :icon="showPassword ? eyeOffOutline : eyeOutline" slot="end" @click="showPassword = !showPassword" />
                   <ion-note slot="helper">{{ translate('will be asked to reset their password when they login', { name: selectedUser.firstName ? selectedUser.firstName : selectedUser.groupName }) }}</ion-note>
                   <ion-note slot="error">{{ translate('Password should be at least 5 characters long and contain at least one number, alphabet and special character.') }}</ion-note>
                 </ion-item>
@@ -361,6 +362,8 @@ import {
   cameraOutline,
   cloudyNightOutline,
   ellipsisVerticalOutline,
+  eyeOffOutline,
+  eyeOutline,
   mailOutline,
   warningOutline
 } from 'ionicons/icons';
@@ -438,7 +441,8 @@ export default defineComponent({
       password: "",
       isUserEnabled: false as boolean,
       imageUrl: "",
-      isUserFetched: false
+      isUserFetched: false,
+      showPassword: false
     }
   },
   async ionViewWillEnter() {
@@ -1054,6 +1058,8 @@ export default defineComponent({
       cameraOutline,
       cloudyNightOutline,
       ellipsisVerticalOutline,
+      eyeOffOutline,
+      eyeOutline,
       hasPermission,
       mailOutline,
       router,

--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -24,7 +24,10 @@
           </ion-item>
           <ion-item ref="password">
             <ion-label position="floating">{{ translate('Password') }} <ion-text color="danger">*</ion-text></ion-label>
-            <ion-input v-model="formData.currentPassword" type="password" autocomplete="new-password" @ionInput="validatePassword" @ionBlur="markPasswordTouched"></ion-input>
+            <ion-input v-model="formData.currentPassword" :type="showPassword ? 'text' : 'password'" autocomplete="new-password" @ionInput="validatePassword" @ionBlur="markPasswordTouched"></ion-input>
+            <ion-button @click="showPassword = !showPassword" slot="end" fill="clear">
+              <ion-icon :icon="showPassword ? eyeOutline : eyeOffOutline" slot="icon-only" />
+            </ion-button>
             <ion-note slot="helper">{{ translate('Password should be at least 5 characters long and contain at least one number, alphabet and special character.') }}</ion-note>
             <ion-note slot="error">{{ translate('Password should be at least 5 characters long and contain at least one number, alphabet and special character.') }}</ion-note>
           </ion-item>
@@ -118,7 +121,9 @@ import {
   addCircleOutline,
   arrowForwardOutline,
   caretDownOutline,
-  documentTextOutline
+  documentTextOutline,
+  eyeOffOutline,
+  eyeOutline
 } from 'ionicons/icons';
 import { copyToClipboard, showToast, isValidPassword, isValidEmail } from '@/utils'
 import { translate } from "@hotwax/dxp-components";
@@ -164,6 +169,7 @@ export default defineComponent({
       facilities: [] as any,
       selectedFacilities: [] as any,
       selectedProductStores: [] as any,
+      showPassword: false,
       formData: {
         userLoginId: '',
         currentPassword: '',
@@ -473,6 +479,8 @@ export default defineComponent({
       arrowForwardOutline,
       caretDownOutline,
       documentTextOutline,
+      eyeOffOutline,
+      eyeOutline,
       translate
     };
   }


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #88

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added eye toggle in password input to show and hide password on toggle.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-01-15 15-57-01](https://github.com/hotwax/user-management/assets/69574321/0241892d-dd79-43e9-978d-8249b9de8b07)
![Screenshot from 2024-01-15 15-57-09](https://github.com/hotwax/user-management/assets/69574321/14134c4c-7a43-41f0-aac0-b052ec933e26)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)