### PR TITLE
Fixed: reset password flag inconsistency in quick-user-setup (#91)

### DIFF
--- a/src/views/UserQuickSetup.vue
+++ b/src/views/UserQuickSetup.vue
@@ -36,7 +36,7 @@
             <ion-label>
               {{ translate("Require password reset on login") }}
             </ion-label>
-            <ion-toggle :checked="formData.requirePasswordChange" slot="end" />
+            <ion-toggle v-model="formData.requirePasswordChange" slot="end" />
           </ion-item>
         </template>
         <ion-item v-if="selectedUserTemplate && selectedUserTemplate.isEmployeeIdRequired && !isFacilityLogin()">


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #91

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed issue in user-quick-setup that isPasswordReset required parameter is always going as 'Y'

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)