### PR TITLE
Fixed: user image not loading on userProfile card due to wrong image url

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -11,7 +11,7 @@
         <ion-card>
           <ion-item lines="full">
             <ion-avatar slot="start" v-if="userProfile?.partyImageUrl">
-              <Image :src="getImageUrl(userProfile.partyImageUrl)"/>
+              <Image :src="userProfile.partyImageUrl"/>
             </ion-avatar>
             <!-- ion-no-padding to remove extra side/horizontal padding as additional padding 
             is added on sides from ion-item and ion-padding-vertical to compensate the removed
@@ -171,9 +171,6 @@ export default defineComponent({
         component: TimezoneModal,
       });
       return timeZoneModal.present();
-    },
-    getImageUrl(imageUrl: string) {
-      return (this.baseUrl.startsWith('http') ? this.baseUrl.replace(/api\/?/, "") : `https://${this.baseUrl}.hotwax.io/`) + imageUrl
     }
   },
   setup () {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed user image loading issue in user-management settins page due to wrong image url being sent to src.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)