### PR TITLE
Fixed: excludedSecurityGroups not parsing due to type conversion (#118)

### DIFF
--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -1029,7 +1029,7 @@ export default defineComponent({
     },
 
     getSecurityGroups(securityGroups: any) {
-      const excludedSecurityGroups = JSON.parse(JSON.stringify(process.env.VUE_APP_EXCLUDED_SECURITY_GROUPS))
+      const excludedSecurityGroups = JSON.parse(process.env.VUE_APP_EXCLUDED_SECURITY_GROUPS as string)
       const selectedSecurityGroup = this.selectedUser.securityGroup.groupId
 
       if(!hasPermission(Actions.APP_SUPER_USER)) excludedSecurityGroups.push('SUPER')


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #118

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed security group selector not showing up due to json parsing error in excludedGroups.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)