### PR TITLE
Fixed: last visited groups permissions showing checked for newly created security group (#135)

### DIFF
--- a/src/views/CreateSecurityGroup.vue
+++ b/src/views/CreateSecurityGroup.vue
@@ -139,6 +139,7 @@ export default defineComponent({
           showToast(translate("Security group created successfully."))
           await this.store.dispatch('util/updateSecurityGroup', this.securityGroups.push(this.formData))
           await this.store.dispatch('permission/updateCurrentGroup', this.formData)
+          await this.store.dispatch('permission/checkAssociated')
           this.router.replace('/add-permissions')
         } else {
           throw resp.data


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #135

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
On succesfull creation of security group, checked for updated association so as to avoid showing last visited security groups permissions on add permissions page.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)