### PR TITLE
Fixed: state not updating on permission association for new security group (#129)

### DIFF
--- a/src/store/modules/permission/actions.ts
+++ b/src/store/modules/permission/actions.ts
@@ -96,7 +96,6 @@ const actions: ActionTree<PermissionState, RootState> = {
     }
 
     commit(types.PERMISSION_BY_CLASSIFICATION_GROUPS_UPDATED, groupTypes)
-    dispatch('checkAssociated')
   },
 
   async getPermissionsByGroup({ state, commit }, groupId) {

--- a/src/store/modules/permission/getters.ts
+++ b/src/store/modules/permission/getters.ts
@@ -37,7 +37,7 @@ const getters: GetterTree<PermissionState, RootState> = {
     return state.currentGroup
   },
   getCurrentGroupPermissions(state) {
-    return state.permissionsByGroup[state.currentGroup.groupId] ? JSON.parse(JSON.stringify(state.permissionsByGroup[state.currentGroup.groupId])) : []
+    return state.permissionsByGroup[state.currentGroup.groupId] ? JSON.parse(JSON.stringify(state.permissionsByGroup[state.currentGroup.groupId])) : {}
   },
   getPermissionsByGroup(state) {
     return state.permissionsByGroup

--- a/src/views/Permissions.vue
+++ b/src/views/Permissions.vue
@@ -122,7 +122,6 @@ export default defineComponent({
     if(!this.allPermissions.length) await this.store.dispatch('permission/getAllPermissions')
     if(!Object.keys(this.permissionsByClassificationGroups).length) await this.store.dispatch('permission/getPermissionsByClassificationGroups')
     if(this.currentGroup.groupId) await this.store.dispatch('permission/getPermissionsByGroup', this.currentGroup.groupId)
-    await this.store.dispatch('permission/checkAssociated')
   },
   methods: {
     createGroup() {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #129

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Fixed the state type returning from the getters groups with 0 associated permissions. This wrong type prevents users to update state on permission association for new security group.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)