### PR TITLE
Fixed: code to show permission description instead of showing of group (#150)

### DIFF
--- a/src/components/EditSecurityGroupModal.vue
+++ b/src/components/EditSecurityGroupModal.vue
@@ -95,8 +95,6 @@ export default defineComponent({
     },
     async updateSecurityGroup() {
       try {
-        console.log(this.group);
-        
         const resp = await UtilService.updateSecurityGroup({
           groupId: this.currentGroup.groupId,
           groupName: this.group.groupName,

--- a/src/components/PermissionItems.vue
+++ b/src/components/PermissionItems.vue
@@ -21,7 +21,7 @@
           <ion-card-header>
             <div>
               <ion-card-title>{{ permission.permissionId }}</ion-card-title>
-              <ion-card-subtitle>{{ permission.description }}</ion-card-subtitle>
+              <ion-card-subtitle>{{ getPermissionDescription(permission.permissionId) }}</ion-card-subtitle>
             </div>
             <ion-checkbox :checked="permission.isChecked" @click="updatePermissionAssociation($event, permission)" />
           </ion-card-header>
@@ -79,7 +79,8 @@ export default defineComponent({
       query: 'permission/getQuery',
       currentGroupPermissions: 'permission/getCurrentGroupPermissions',
       currentGroup: "permission/getCurrentGroup",
-      filteredPermissions: "permission/getFilteredPermissions"
+      filteredPermissions: "permission/getFilteredPermissions",
+      getPermissionDescription: "permission/getPermissionDescription"
     })
   },
   methods: {

--- a/src/store/modules/permission/actions.ts
+++ b/src/store/modules/permission/actions.ts
@@ -7,8 +7,8 @@ import { hasError } from '@/adapter'
 
 const actions: ActionTree<PermissionState, RootState> = {
   async getAllPermissions({ commit }) {
-    let permissions = [] as any, resp;
-    let viewIndex = 0;
+    const permissions = {} as any;
+    let viewIndex = 0, resp;
 
     try {
       do {
@@ -22,7 +22,9 @@ const actions: ActionTree<PermissionState, RootState> = {
         })
 
         if (!hasError(resp) && resp.data.count) {
-          permissions = permissions.concat(resp.data.docs)
+          resp.data.docs.map((permission: any) => {
+            permissions[permission.permissionId] = permission
+          })
           viewIndex++;
         } else {
           throw resp.data
@@ -81,10 +83,10 @@ const actions: ActionTree<PermissionState, RootState> = {
     })
 
     // Filtering all the permissions which are not part of any group type.
-    let otherPermissions = JSON.parse(JSON.stringify(state.allPermissions))
+    const otherPermissions = JSON.parse(JSON.stringify(state.allPermissions))
     Object.values(groupTypes).map((group: any) => {
       group.permissions.map((permission: any) => {
-        otherPermissions = otherPermissions.filter((perm: any) => perm.permissionId !== permission.permissionId)
+        delete otherPermissions[permission.permissionId]
       })
     })
 
@@ -92,7 +94,7 @@ const actions: ActionTree<PermissionState, RootState> = {
     groupTypes['OTHERS'] = {
       groupId: 'OTHERS',
       groupName: 'Other Category',
-      permissions: otherPermissions
+      permissions: Object.values(otherPermissions)
     }
 
     commit(types.PERMISSION_BY_CLASSIFICATION_GROUPS_UPDATED, groupTypes)

--- a/src/store/modules/permission/getters.ts
+++ b/src/store/modules/permission/getters.ts
@@ -44,6 +44,9 @@ const getters: GetterTree<PermissionState, RootState> = {
   },
   getAllPermissions(state) {
     return state.allPermissions
+  },
+  getPermissionDescription: (state) =>(permissionId: any) => {
+    return state.allPermissions[permissionId]?.description
   }
 }
 export default getters;

--- a/src/store/modules/permission/getters.ts
+++ b/src/store/modules/permission/getters.ts
@@ -45,7 +45,7 @@ const getters: GetterTree<PermissionState, RootState> = {
   getAllPermissions(state) {
     return state.allPermissions
   },
-  getPermissionDescription: (state) =>(permissionId: any) => {
+  getPermissionDescription: (state) => (permissionId: any) => {
     return state.allPermissions[permissionId]?.description
   }
 }

--- a/src/store/modules/permission/getters.ts
+++ b/src/store/modules/permission/getters.ts
@@ -46,7 +46,7 @@ const getters: GetterTree<PermissionState, RootState> = {
     return state.allPermissions
   },
   getPermissionDescription: (state) => (permissionId: any) => {
-    return state.allPermissions[permissionId]?.description
+    return state.allPermissions[permissionId]?.description ? state.allPermissions[permissionId].description : state.allPermissions[permissionId].permissionId
   }
 }
 export default getters;

--- a/src/store/modules/permission/getters.ts
+++ b/src/store/modules/permission/getters.ts
@@ -46,7 +46,7 @@ const getters: GetterTree<PermissionState, RootState> = {
     return state.allPermissions
   },
   getPermissionDescription: (state) => (permissionId: any) => {
-    return state.allPermissions[permissionId]?.description ? state.allPermissions[permissionId].description : state.allPermissions[permissionId].permissionId
+    return state.allPermissions[permissionId]?.description ? state.allPermissions[permissionId].description : permissionId
   }
 }
 export default getters;

--- a/src/store/modules/permission/index.ts
+++ b/src/store/modules/permission/index.ts
@@ -15,7 +15,7 @@ const permissionModule: Module<PermissionState, RootState> = {
     },
     currentGroup: {},
     permissionsByGroup: {},
-    allPermissions: []
+    allPermissions: {}
   },
   getters,
   actions,


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #150

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Displayed permission description in permission card instead of showing group description.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
Before
![Screenshot from 2024-03-06 18-36-34](https://github.com/hotwax/user-management/assets/69574321/27e7fb46-e41b-4789-9e22-224f8c3eb46b)

After
![Screenshot from 2024-03-06 18-36-37](https://github.com/hotwax/user-management/assets/69574321/6eac930b-6796-435c-b567-936ae2dd8172)

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)