### PR TITLE
Fixed: querystring persist on searchbar on group change if not updated in state by keyEnter event (#132)

### DIFF
--- a/src/components/PermissionItems.vue
+++ b/src/components/PermissionItems.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="search-permissions">
-    <ion-searchbar :placeholder="translate('Search permissions')" :value="query.queryString" @keyup.enter="query.queryString = $event.target.value; updateQuery()" />
+    <ion-searchbar :placeholder="translate('Search permissions')" v-model="query.queryString" @ionInput="updateQuery()" />
     <ion-item lines="none">
       <ion-icon :icon="shieldCheckmarkOutline" slot="start" />
       <ion-label>{{ translate("Only selected permissions") }}</ion-label>

--- a/src/views/Permissions.vue
+++ b/src/views/Permissions.vue
@@ -243,7 +243,7 @@ export default defineComponent({
           } while (resp.data.docs.length >= 250);
         }));
       } catch (err) {
-        console.log(err);
+        console.error(err);
       }
 
       return permissionsByGroup;


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #132

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Currently the updateQuery is called on enter key hit. Which results in query to persist on group change if enter key is not hit. Because component is not rendered again on group change.

To fix updated the code to call updateQuery function on the key input.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)