### PR TITLE
Improved: code by avoiding the change in internalId when group name is renamed(#115)

### DIFF
--- a/src/views/CreateSecurityGroup.vue
+++ b/src/views/CreateSecurityGroup.vue
@@ -12,7 +12,7 @@
         <ion-list>
           <ion-item>
             <ion-label position="floating">{{ translate('Name') }}</ion-label>
-            <ion-input @ionBlur="setGroupId($event)" v-model="formData.groupName" />
+            <ion-input @ionBlur="formData.groupId ? null : setGroupId($event)" v-model="formData.groupName" />
           </ion-item>
           <ion-item ref="groupId">
             <ion-label position="floating">{{ translate('Internal ID') }}</ion-label>


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related issue  #115 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->

After the creation of security group, when we edit its name then internal ID won't gets affected/changed.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)