### PR TITLE
Improved: conditions to show alert only if a group is selected and no permission associated (#134)

### DIFF
--- a/src/views/Permissions.vue
+++ b/src/views/Permissions.vue
@@ -176,7 +176,7 @@ export default defineComponent({
       this.router.replace('users')
     },
     async downloadCSVForPermissions() {
-      if(!Object.keys(this.currentGroupPermissions).length) {
+      if(this.currentGroup.groupId && !Object.keys(this.currentGroupPermissions).length) {
         const alert = await alertController.create({
           header: translate("No permissions associated"),
           message: translate("No permissions have been linked to this group yet. Permissions for a group cannot be downloaded."),


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #134

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Improved csv download logic for permissions such as --
- Download all groups permissions when no security group is selected.
- Show alert if a group is selected but no permissions are associated with that group.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)