### PR TITLE
Fixed: duplicate toast on updating product store and unnecessary toast when redirecting using created by user (#172)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -191,7 +191,7 @@ const getUserFavorites = async (payload: any): Promise<any> => {
       throw resp.data;
     }
   } catch (error) {
-    console.log(error)
+    logger.error(error)
   }
   return favorites;
 }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -420,7 +420,7 @@ const actions: ActionTree<UserState, RootState> = {
     } catch (error) {
       showToast(translate("Failed to set favorite shopify shop."));
       logger.error(error);
-      Promise.reject(error)
+      return Promise.reject(error)
     }
   }
 }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -398,7 +398,6 @@ const actions: ActionTree<UserState, RootState> = {
         throw resp.data;
       }
     } catch (error) {
-      showToast(translate("Failed to set favorite product store."));
       logger.error(error);
       return Promise.reject(error)
     }
@@ -418,7 +417,6 @@ const actions: ActionTree<UserState, RootState> = {
         throw resp.data;
       }
     } catch (error) {
-      showToast(translate("Failed to set favorite shopify shop."));
       logger.error(error);
       return Promise.reject(error)
     }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -393,7 +393,7 @@ const actions: ActionTree<UserState, RootState> = {
         commit(types.USER_SELECTED_USER_UPDATED, {...this.state.user.selectedUser, favoriteProductStorePref: params})
         //removing favorite shop on change of favorite product store
         dispatch('setFavoriteShopifyShop', {'userLoginId': payload.userLoginId, 'shopId': ''});
-        return Promise.resolve({ favoriteProductStorePref: params })
+        return Promise.resolve(resp.data)
       } else {
         throw resp.data;
       }
@@ -413,7 +413,7 @@ const actions: ActionTree<UserState, RootState> = {
       const resp = await UserService.setUserPreference(params);
       if (!hasError(resp)) {
         commit(types.USER_SELECTED_USER_UPDATED, {...this.state.user.selectedUser, favoriteShopifyShopPref: params})
-        return Promise.resolve({ favoriteProductStorePref: params })
+        return Promise.resolve(resp.data)
       } else {
         throw resp.data;
       }

--- a/src/store/modules/user/actions.ts
+++ b/src/store/modules/user/actions.ts
@@ -393,13 +393,14 @@ const actions: ActionTree<UserState, RootState> = {
         commit(types.USER_SELECTED_USER_UPDATED, {...this.state.user.selectedUser, favoriteProductStorePref: params})
         //removing favorite shop on change of favorite product store
         dispatch('setFavoriteShopifyShop', {'userLoginId': payload.userLoginId, 'shopId': ''});
-        showToast(translate('Favorite product store updated successfully.'));
+        return Promise.resolve({ favoriteProductStorePref: params })
       } else {
         throw resp.data;
       }
     } catch (error) {
       showToast(translate("Failed to set favorite product store."));
-      console.log(error);
+      logger.error(error);
+      return Promise.reject(error)
     }
   },
   async setFavoriteShopifyShop({ commit }, payload) {
@@ -412,13 +413,14 @@ const actions: ActionTree<UserState, RootState> = {
       const resp = await UserService.setUserPreference(params);
       if (!hasError(resp)) {
         commit(types.USER_SELECTED_USER_UPDATED, {...this.state.user.selectedUser, favoriteShopifyShopPref: params})
-        showToast(translate('Favorite shopify shop updated successfully.'));
+        return Promise.resolve({ favoriteProductStorePref: params })
       } else {
         throw resp.data;
       }
     } catch (error) {
       showToast(translate("Failed to set favorite shopify shop."));
-      console.log(error);
+      logger.error(error);
+      Promise.reject(error)
     }
   }
 }

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -522,6 +522,8 @@ export default defineComponent({
         .then(() => {
           this.getShopifyShops(selectedProductStoreId);
           showToast(translate('Favorite product store updated successfully.'));
+        }).catch(() =>{
+          showToast(translate("Failed to set favorite product store."));
         })
       }
     },
@@ -531,6 +533,8 @@ export default defineComponent({
         this.store.dispatch('user/setFavoriteShopifyShop', {"userLoginId": this.selectedUser?.userLoginId, "shopId": selectedShopId})
         .then(() => {
           showToast(translate('Favorite shopify shop updated successfully.'));
+        }).catch(() => {
+          showToast(translate("Failed to set favorite shopify shop."));
         })
       }
     },

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -502,7 +502,7 @@ export default defineComponent({
     await this.store.dispatch("user/getSelectedUserDetails", { partyId: this.partyId, isFetchRequired: true });
     await this.fetchProfileImage()
     await Promise.all([this.store.dispatch('util/getSecurityGroups'), this.store.dispatch('util/fetchShopifyShopConfigs')]);
-
+    
     const productStoreId = this.selectedUser.favoriteProductStorePref?.userPrefValue;
     if (productStoreId) {
       this.getShopifyShops(productStoreId);

--- a/src/views/UserDetails.vue
+++ b/src/views/UserDetails.vue
@@ -502,7 +502,7 @@ export default defineComponent({
     await this.store.dispatch("user/getSelectedUserDetails", { partyId: this.partyId, isFetchRequired: true });
     await this.fetchProfileImage()
     await Promise.all([this.store.dispatch('util/getSecurityGroups'), this.store.dispatch('util/fetchShopifyShopConfigs')]);
-    
+
     const productStoreId = this.selectedUser.favoriteProductStorePref?.userPrefValue;
     if (productStoreId) {
       this.getShopifyShops(productStoreId);
@@ -517,15 +517,21 @@ export default defineComponent({
     },
     updateFavoriteProductStore(event: any) {
       const selectedProductStoreId = event.target.value;
-      if (selectedProductStoreId && selectedProductStoreId !== this.selectedUser?.favoriteProductStorePref?.userPrefTypeId) {
+      if (selectedProductStoreId && selectedProductStoreId !== this.selectedUser?.favoriteProductStorePref?.userPrefValue) {
         this.store.dispatch('user/setFavoriteProductStore', {"userLoginId": this.selectedUser?.userLoginId, "productStoreId": selectedProductStoreId})
-        this.getShopifyShops(selectedProductStoreId);
+        .then(() => {
+          this.getShopifyShops(selectedProductStoreId);
+          showToast(translate('Favorite product store updated successfully.'));
+        })
       }
     },
     updateFavoriteShopifyShop(event: any) {
       const selectedShopId = event.target.value;
-      if (selectedShopId && selectedShopId !== this.selectedUser?.favoriteShopifyShopPref?.userPrefTypeId) {
+      if (selectedShopId && selectedShopId !== this.selectedUser?.favoriteShopifyShopPref?.userPrefValue) {
         this.store.dispatch('user/setFavoriteShopifyShop', {"userLoginId": this.selectedUser?.userLoginId, "shopId": selectedShopId})
+        .then(() => {
+          showToast(translate('Favorite shopify shop updated successfully.'));
+        })
       }
     },
     async openContactActionsPopover(event: Event, type: string, value: string) {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue #172

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- Removed unnecessary toast getting displayed on going to details page from created by user tab.
- Removed duplicate toast getting displayed on updating favorites product store.


### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/import#contribution-guideline)