### PR TITLE
Stop scanning Shopify BOPIS permissions

### DIFF
--- a/docs/permission-audit/app-roots.json
+++ b/docs/permission-audit/app-roots.json
@@ -14,7 +14,6 @@
   { "appId": "receiving", "root": "../receiving" },
   { "appId": "reroute-fulfilment", "root": "../reroute-fulfilment" },
   { "appId": "returns", "root": "../returns", "allowNoPermissions": true },
-  { "appId": "shopify-bopis", "root": "../shopify-bopis", "allowNoPermissions": true },
   { "appId": "transfers", "root": "../transfers" },
   { "appId": "users", "root": "." }
 ]

--- a/docs/permission-audit/generated/permission-usage.json
+++ b/docs/permission-audit/generated/permission-usage.json
@@ -1147,12 +1147,6 @@
       "permissions": []
     },
     {
-      "appId": "shopify-bopis",
-      "root": "../shopify-bopis",
-      "allowNoPermissions": true,
-      "permissions": []
-    },
-    {
       "appId": "transfers",
       "root": "../transfers",
       "permissions": [


### PR DESCRIPTION
## Summary

- remove Shopify BOPIS from the permission-audit app roots
- remove its empty entry from the committed generated audit snapshot

## Why

Shopify BOPIS is no longer an application surfaced by Company App Permissions, so the local audit scanner should not retain or regenerate an entry for it.

## Validation

- permission audit scanner completed successfully with 17 configured apps after removing the root
- app-root IDs and generated audit app IDs match
- Shopify BOPIS is absent from both files
- `git diff --check` — passed